### PR TITLE
Corrected theme item off-by-1 pixel error

### DIFF
--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -36,6 +36,7 @@
 .theme__item {
   position: relative;
   display: inline-block;
+  vertical-align: top;
 }
 
 .theme__item + .theme__item {


### PR DESCRIPTION
Just quickly changing this:

![chrome_2018-07-21_14-03-07](https://user-images.githubusercontent.com/22254235/43032697-d8d9314c-8cef-11e8-8b55-1698e1d6dcb1.png)

into this:

![chrome_2018-07-21_14-04-29](https://user-images.githubusercontent.com/22254235/43032699-e1e5663e-8cef-11e8-9478-8ff4f0eb5a8c.png)
